### PR TITLE
Remove _base_manager attribute for Django 1.10 support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,16 +1,10 @@
 dependencies:
-  post:
-    - python setup.py develop
-    - pip install -r tests/requirements.txt
-
-test:
   override:
-    - cd tests/test_project && python manage.py test test_project.viewtest --settings=test_project.settings.ci
-    - pip uninstall -y django && pip install django==1.8
-    - cd tests/test_project && python manage.py test test_project.viewtest --settings=test_project.settings.ci
-    - pyenv global 3.5.0
-    - cd tests/test_project && python manage.py test test_project.viewtest --settings=test_project.settings.ci
-
+    - pip install tox tox-pyenv
+  post:
+    - pyenv global 2.7.10 3.4.3 3.5.0
+  pre:
+    - sudo apt-get install python3-dev -y
 notify:
   webhooks:
     - url: https://webhooks.gitter.im/e/094571daa52845626f62

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,1 @@
-Django==1.9
 psycopg2

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py{27,34,35}-dj{18,19,110,master}
+
+[testenv]
+usedevelop = true
+setenv =
+    DJANGO_SETTINGS_MODULE = test_project.settings.ci
+changedir = {toxinidir}/tests/test_project
+deps=
+    -rtests/requirements.txt
+    dj18: https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
+    dj19: https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
+    dj110: https://github.com/django/django/archive/stable/1.10.x.tar.gz#egg=django
+    djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django
+commands=
+    python manage.py test  {posargs:test_project.viewtest}


### PR DESCRIPTION
I based this on my tox commit, so see if CI passes.